### PR TITLE
Remove a comment

### DIFF
--- a/model/nntool_scripts/nntool_script_demo_mixed_precision
+++ b/model/nntool_scripts/nntool_script_demo_mixed_precision
@@ -5,7 +5,7 @@ fusions --scale8
 nodeoption GRU_74 RNN_STATES_AS_INPUTS 1
 nodeoption GRU_136 RNN_STATES_AS_INPUTS 1
 
-#run_pyscript model/nntool_scripts/collect_stats.py samples/quant/ 8 $(GRU) $(MODEL_BUILD)/ $(H_STATE_LEN)
+run_pyscript model/nntool_scripts/collect_stats.py samples/quant/ 8 $(GRU) $(MODEL_BUILD)/ $(H_STATE_LEN)
 aquant --stats $(MODEL_BUILD)/data_quant.json
 
 qtune --step * clip_type=none


### PR DESCRIPTION
I removed the comment from the line 8 (run_pyscript) in the nntool_script_demo_mixed_precision file. This line is used to generate the data_quant.json which is used for the quantization.